### PR TITLE
ECC: declutter view header (drop titles, move select-all + action menu left)

### DIFF
--- a/public/js/ecc.js
+++ b/public/js/ecc.js
@@ -14,8 +14,6 @@
 	var trashBtn;
 	var resetTriageBtn;
 	var viewHeader;
-	var viewTitle;
-	var viewSubtitle;
 	var listWrap;
 	var detailEl;
 	var detailBackBtn;
@@ -1049,24 +1047,6 @@
 		});
 	}
 
-	function updateViewText() {
-		if (!viewTitle || !viewSubtitle) return;
-		var projectName = selectedProject
-			? projectSelect?.options[projectSelect.selectedIndex]?.text || 'selected project'
-			: 'all projects';
-		if (activeLabel) {
-			var labelBtn = labelsEl?.querySelector('[data-label="' + activeLabel + '"]');
-			viewTitle.textContent = labelBtn?.querySelector('.ecc-label-name')?.textContent || activeLabel;
-			viewSubtitle.textContent = 'Emails labeled ' + viewTitle.textContent + ' in ' + projectName + '.';
-			return;
-		}
-			var names = { inbox: 'Inbox', archived: 'Archived', sent: 'Sent', spam: 'Spam', drafts: 'Drafts', trash: 'Trash' };
-			viewTitle.textContent = names[activeMailbox] || 'Inbox';
-			viewSubtitle.textContent = activeMailbox === 'inbox'
-				? 'All untriaged emails in ' + projectName + '.'
-				: (names[activeMailbox] || 'Emails') + ' in ' + projectName + '.';
-		}
-
 	function renderLabels(labels) {
 		if (!labelsEl) return;
 		if (!labels.length) {
@@ -1174,11 +1154,6 @@
 			selectedIds.clear();
 			updateActionBar();
 			renderMoveMenu();
-			if (viewTitle) viewTitle.textContent = 'Email AI results';
-			if (viewSubtitle) {
-				var total = Number.isFinite(count) ? count : emails.length;
-				viewSubtitle.textContent = total === 1 ? '1 matching email.' : total + ' matching emails.';
-			}
 			if (!emails.length) {
 				listEl.innerHTML = '<div class="list-group-item text-muted ecc-email-empty">' + escapeHtml(answer || 'No matching emails.') + '</div>';
 				updateActionBar();
@@ -2389,7 +2364,6 @@
 		}
 
 		async function loadAll() {
-			updateViewText();
 			try {
 				await Promise.all([loadLabels(), loadEmails()]);
 			} catch (err) {
@@ -2629,8 +2603,6 @@
 		trashBtn = document.getElementById('ecc-trash-btn');
 		resetTriageBtn = document.getElementById('ecc-reset-triage-btn');
 		viewHeader = document.getElementById('ecc-view-header');
-		viewTitle = document.getElementById('ecc-view-title');
-		viewSubtitle = document.getElementById('ecc-view-subtitle');
 		listWrap = document.getElementById('ecc-list-wrap');
 		detailEl = document.getElementById('ecc-detail');
 		detailBackBtn = document.getElementById('ecc-detail-back-btn');
@@ -2732,8 +2704,6 @@
 		moveMenu = null;
 		trashBtn = null;
 		resetTriageBtn = null;
-		viewTitle = null;
-		viewSubtitle = null;
 		listWrap = null;
 		detailEl = null;
 		detailBackBtn = null;

--- a/views/ajax/section/ecc.pug
+++ b/views/ajax/section/ecc.pug
@@ -46,32 +46,29 @@ else
 				.list-group-item.text-muted.small Loading labels...
 		.ecc-main
 			.d-flex.justify-content-between.align-items-center.mb-3#ecc-view-header
-				div
-					h5.mb-1#ecc-view-title Inbox
-					p.text-muted.small.mb-0#ecc-view-subtitle All untriaged emails across projects.
+				.d-flex.align-items-center.gap-2
+					button.btn.btn-outline-secondary.btn-sm#ecc-select-all-btn.d-none(type="button" title="Select all visible emails" aria-pressed="false")
+						!= icon('checkSquare', 'me-1')
+						span#ecc-select-all-text Select all
+					.d-none.align-items-center.gap-2#ecc-action-bar
+						span.badge.text-bg-secondary#ecc-action-count 0 selected
+						.dropdown
+							button.btn.btn-outline-secondary.btn-sm.dropdown-toggle#ecc-move-btn(type="button" data-bs-toggle="dropdown" aria-expanded="false")
+								!= icon('drive_file_move', 'me-1')
+								span Move
+							ul.dropdown-menu#ecc-move-menu(aria-labelledby="ecc-move-btn")
+						button.btn.btn-outline-secondary.btn-sm#ecc-reset-triage-btn(type="button")
+							!= icon('restore', 'me-1')
+							span Reset triage
+						button.btn.btn-outline-danger.btn-sm#ecc-trash-btn(type="button")
+							!= icon('delete', 'me-1')
+							span.ecc-trash-text Trash
 				.d-flex.align-items-center.gap-2
 					button.btn.btn-primary.btn-sm#ecc-triage-btn(type="button")
 						!= icon('sparkle', 'me-1')
 						span Triage Inbox
-					button.btn.btn-outline-secondary.btn-sm#ecc-select-all-btn.d-none(type="button" title="Select all visible emails" aria-pressed="false")
-						!= icon('checkSquare', 'me-1')
-						span#ecc-select-all-text Select all
 					button.btn.btn-outline-secondary.btn-sm#ecc-refresh-btn(type="button" title="Refresh")
 						!= icon('sync')
-			.d-none.align-items-center.justify-content-between.mb-3#ecc-action-bar
-				span.badge.text-bg-secondary#ecc-action-count 0 selected
-				.d-flex.align-items-center.gap-2
-					.dropdown
-						button.btn.btn-outline-secondary.btn-sm.dropdown-toggle#ecc-move-btn(type="button" data-bs-toggle="dropdown" aria-expanded="false")
-							!= icon('drive_file_move', 'me-1')
-							span Move
-						ul.dropdown-menu.dropdown-menu-end#ecc-move-menu(aria-labelledby="ecc-move-btn")
-					button.btn.btn-outline-secondary.btn-sm#ecc-reset-triage-btn(type="button")
-						!= icon('restore', 'me-1')
-						span Reset triage
-					button.btn.btn-outline-danger.btn-sm#ecc-trash-btn(type="button")
-						!= icon('delete', 'me-1')
-						span.ecc-trash-text Trash
 			#ecc-list-wrap
 				#ecc-list.list-group
 			#ecc-detail.d-none


### PR DESCRIPTION
## What changed

Restructured the ECC (Email Command Center) main view header (`#ecc-view-header`):

1. **Removed the per-section title/subtitle** (`#ecc-view-title` + `#ecc-view-subtitle`) — the active mailbox/label is already obvious from the left navigation, so the heading was redundant.
2. **Moved "Select all"** (`#ecc-select-all-btn`) to the **left** of the toolbar. Triage Inbox and Refresh stay on the right.
3. **Inlined the bulk action menu** (`#ecc-action-bar`: selected-count badge, Move, Reset triage, Trash) immediately to the right of the select/deselect toggle, instead of on its own row below. Dropped `dropdown-menu-end` on the Move menu so it opens left-aligned in its new position.

## Cleanup

Removed the now-dead title JS in `public/js/ecc.js`: `viewTitle`/`viewSubtitle` vars and their lookup/cleanup, the `updateViewText()` function and its call in `loadAll()`, and the title/subtitle writes in `renderEmailAiResultEmails()`. Kept `viewHeader` — `showListView`/`showDetailView` still toggle `d-none` on the whole header (which now also hides select-all + the action bar in detail view).

## Notes for reviewers

- `updateActionBar` still toggles `d-none`/`d-flex` on `#ecc-action-bar` by selection count; works unchanged with the new nesting.
- Verified: `node --check` on ecc.js passes, `pug.compileFile` on ecc.pug passes, no remaining references to removed identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)